### PR TITLE
PHPのバージョンを最新に更新

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3.6-fpm-alpine
+FROM php:7.3.9-fpm-alpine
 
 ENV COMPOSER_ALLOW_SUPERUSER 1
 


### PR DESCRIPTION
# 課題URL（JIRAかGitHub issue）
https://github.com/nurse-senka/php-development-docker/issues/8

# PRのDoneの定義
- PHPのバージョンが7.3.9に変更されている事

# 変更点概要
- PHPのバージョンを7.3.9に変更

# 補足情報
下記の情報を参考に脆弱性の影響を受けない7.3.9にUpgrade

https://news.mynavi.jp/article/20190909-889929/